### PR TITLE
Ruby 4 Compatibility + Version Bump to 1.2.0

### DIFF
--- a/lib/polish_number.rb
+++ b/lib/polish_number.rb
@@ -39,10 +39,10 @@ module PolishNumber
     if number == 0
       result = ZERO.dup
     else
-      formatted_number = sprintf('%09.0f', number)
+      formatted_number = format('%09d', number)
       digits = formatted_number.chars.map { |char| char.to_i }
 
-      result = ''
+      result = String.new
       result << process_0_999(digits[0..2])
       result << millions(number/1000000, digits[0..2])
       result << ' '
@@ -65,7 +65,7 @@ module PolishNumber
   private
 
   def self.process_0_999(digits)
-    result = ''
+    result = String.new
     result << HUNDREDS[digits[0]]
 
     if digits[1] == 1 && digits[2] != 0

--- a/lib/polish_number/version.rb
+++ b/lib/polish_number/version.rb
@@ -1,3 +1,3 @@
 module PolishNumber
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION

 ### Summary

 This PR adds Ruby 4 compatibility fixes and bumps the gem version to 1.2.0.

 ### Changes

 #### Ruby 4 Compatibility

 - Frozen string literals: Replaced empty string literals ('') with String.new to avoid frozen string errors in Ruby 4
 - Integer formatting: Changed sprintf('%09.0f', number) to format('%09d', number) for proper integer formatting without float conversion

 #### Version Bump

 - Updated gem version from 1.1.1 to 1.2.0

 ### Testing

 All existing tests pass with these changes. The modifications are backward compatible with Ruby 3.x.

 ### Motivation

 Ruby 4 introduces stricter frozen string literal handling. These changes ensure the gem works correctly on Ruby 4 while maintaining
 compatibility with Ruby 3.0+.

